### PR TITLE
👍 認証をCookieからAuthorizationヘッダーで行うように変更

### DIFF
--- a/src/app/service/api.interface.ts
+++ b/src/app/service/api.interface.ts
@@ -5,7 +5,7 @@ export type SignUpReq = {
 };
 
 export type SignUpRes = {
-  username: string;
+  accessToken: string;
 };
 
 export type SignInReq = {
@@ -14,7 +14,7 @@ export type SignInReq = {
 };
 
 export type SignInRes = {
-  username: string;
+  accessToken: string;
 };
 
 export type GetQuestionRes = {

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -1,6 +1,6 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Observable, tap } from 'rxjs';
 import ENV from '../../environments/environment.json';
 import {
   ApiError,
@@ -21,64 +21,57 @@ export class ApiService {
   baseUrl = ENV.API_BASE;
 
   /** 新規登録 */
-  signUp(data: SignUpReq): Observable<SignUpRes | ApiError> {
-    return this.httpClient.post<SignUpRes | ApiError>(
-      this.baseUrl + '/signup',
-      data,
-      {
-        withCredentials: true,
-      }
-    );
+  signUp(data: SignUpReq) {
+    return this.httpClient
+      .post<SignUpRes | ApiError>(this.baseUrl + '/signup', data)
+      .pipe(
+        tap((res) => {
+          if (!isApiError(res)) this.setToken(res.accessToken);
+        })
+      );
   }
 
   /** ログイン */
-  signIn(data: SignInReq): Observable<SignInRes | ApiError> {
-    return this.httpClient.post<SignInReq>(this.baseUrl + '/signin', data, {
-      withCredentials: true,
-    });
+  signIn(data: SignInReq) {
+    return this.httpClient
+      .post<SignInRes | ApiError>(this.baseUrl + '/signin', data)
+      .pipe(
+        tap((res) => {
+          if (!isApiError(res)) this.setToken(res.accessToken);
+        })
+      );
   }
 
   /** 問題取得 */
-  getQuestion(id: number): Observable<GetQuestionRes | ApiError> {
-    // いったんダミーのデータ
-    return of({
-      questionId: id,
-      imageUrl: 'https://placehold.jp/150x150.png',
-      choices: [
-        {
-          choiceId: 1,
-          text: 'フライパン',
-        },
-        {
-          choiceId: 2,
-          text: 'フランスパン',
-        },
-        {
-          choiceId: 3,
-          text: '食パン',
-        },
-        {
-          choiceId: 4,
-          text: '肩パン',
-        },
-      ],
-      correctChoiceId: 1,
-    });
-    // return this.httpClient.get<GetQuestionRes | ApiError>(
-    //   this.baseUrl + "/questions/" + id,
-    //   {
-    //     withCredentials: true,
-    //   },
-    // );
+  getQuestion(id: number) {
+    return this.get<GetQuestionRes>('/questions/' + id);
   }
 
+  /** 問題送信 */
   postAnswer(questionId: number, data: PostQuestionAnswerReq) {
-    return of({});
-    // return this.httpClient.post<ApiError>(
-    //   this.baseUrl + '/questions/' + questionId + '/answer',
-    //   data,
-    //   { withCredentials: true }
-    // );
+    return this.post('/questions/' + questionId + '/answer', data);
+  }
+
+  /** 認証付きGETリクエスト */
+  private get<T = {}>(path: string) {
+    return this.httpClient.get<T | ApiError>(this.baseUrl + path, {
+      headers: { Authorization: `Bearer ${this.getToken()}` },
+    });
+  }
+
+  /** 認証付きPOSTリクエスト */
+  private post<T = {}>(path: string, body: any | null) {
+    return this.httpClient.post<T | ApiError>(this.baseUrl + path, body, {
+      headers: { Authorization: `Bearer ${this.getToken()}` },
+    });
+  }
+
+  private setToken(accessToken: string) {
+    localStorage.setItem('token', accessToken);
+  }
+
+  private getToken() {
+    return localStorage.getItem('token');
   }
 }
 

--- a/src/app/signup/signup.component.ts
+++ b/src/app/signup/signup.component.ts
@@ -1,41 +1,38 @@
-import { Component, inject } from "@angular/core";
-import { ApiService, isApiError } from "../service/api.service";
-import { FormControl, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { Component, inject } from '@angular/core';
+import { ApiService, isApiError } from '../service/api.service';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
-  selector: "app-signup",
+  selector: 'app-signup',
   imports: [ReactiveFormsModule],
-  templateUrl: "./signup.component.html",
-  styleUrl: "./signup.component.scss",
+  templateUrl: './signup.component.html',
+  styleUrl: './signup.component.scss',
 })
 export class SignupComponent {
   api = inject(ApiService);
 
   formData = new FormGroup({
-    username: new FormControl(""),
-    password: new FormControl(""),
-    inviteCode: new FormControl(""),
+    username: new FormControl(''),
+    password: new FormControl(''),
+    inviteCode: new FormControl(''),
   });
 
-  result = "";
+  result = '';
 
   submit() {
     console.log(this.formData.value);
     const data = {
-      username: this.formData.value.username ?? "",
-      password: this.formData.value.password ?? "",
-      inviteCode: this.formData.value.inviteCode ?? "",
+      username: this.formData.value.username ?? '',
+      password: this.formData.value.password ?? '',
+      inviteCode: this.formData.value.inviteCode ?? '',
     };
 
-    this.api.signUp(data).subscribe(
-      (data) => {
-        if (isApiError(data)) {
-          this.result =
-            `新規登録に失敗しました。${data.error.message}（${data.error.code}）`;
-          return;
-        }
-        this.result = data.username + " で新規登録が完了しました🎉";
-      },
-    );
+    this.api.signUp(data).subscribe((res) => {
+      if (isApiError(res)) {
+        this.result = `新規登録に失敗しました。${res.error.message}（${res.error.code}）`;
+        return;
+      }
+      this.result = data.username + ' で新規登録が完了しました🎉';
+    });
   }
 }


### PR DESCRIPTION
- 新規登録・ログイン時に帰ってきたアクセストークンをLocalStorage に保存するようにしました
- 認証情報を付けてGET、POSTする関数を api.service.ts に追加しました