### PR TITLE
👍 トップページで状態をポーリングして適切な表示をするように変更

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,8 +13,4 @@
   <a [routerLink]="'/control'">管理画面</a>
 </div>
 
-<div>
-  <a [routerLink]="['question', 1]">問題１</a>
-</div>
-
 <router-outlet />

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,9 +6,10 @@ import { WaitingComponent } from './waiting/waiting.component';
 import { ControlComponent } from './control/control.component';
 import { RegisterComponent } from './control/register/register.component';
 import { StatusComponent } from './control/status/status.component';
-import { QuestionComponent } from './question/question.component';
+import { PlayerComponent } from './player/player.component';
 
 export const routes: Routes = [
+  { path: '', component: PlayerComponent },
   {
     path: 'signup',
     component: SignupComponent,
@@ -38,9 +39,5 @@ export const routes: Routes = [
         component: StatusComponent,
       },
     ],
-  },
-  {
-    path: 'question/:id',
-    component: QuestionComponent,
   },
 ];

--- a/src/app/player/player.component.html
+++ b/src/app/player/player.component.html
@@ -1,0 +1,7 @@
+@if (status().status === "waiting") {
+  <div>まだ回答は始まっていません</div>
+} @else if (status().status === "finish") {
+  <div>問題は終了しました</div>
+} @else if (status().status === "open" || status().status === "close") {
+  <app-question [nowStatus]="status()" />
+}

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -1,0 +1,49 @@
+import { Component, inject, signal } from '@angular/core';
+import { ApiService, isApiError } from '../service/api.service';
+import { interval, Subscription } from 'rxjs';
+import { Status } from '../service/api.interface';
+import { QuestionComponent } from '../question/question.component';
+
+@Component({
+  selector: 'app-player',
+  imports: [QuestionComponent],
+  templateUrl: './player.component.html',
+  styleUrl: './player.component.scss',
+})
+export class PlayerComponent {
+  private readonly apiService = inject(ApiService);
+
+  pollingSubscription: Subscription | undefined;
+
+  /** 現在のステータス */
+  status = signal<Status>(
+    { status: 'waiting' },
+    {
+      equal: (a, b) => {
+        return JSON.stringify(a) === JSON.stringify(b);
+      },
+    },
+  );
+
+  ngOnInit() {
+    this.updateStatus();
+    // ポーリングでステータスを取得
+    this.pollingSubscription = interval(3000).subscribe(() => {
+      this.updateStatus();
+    });
+  }
+
+  ngOnDestroy() {
+    this.pollingSubscription?.unsubscribe();
+  }
+
+  updateStatus() {
+    this.apiService.getStatus().subscribe((data) => {
+      if (isApiError(data)) return;
+      this.status.set(data);
+      if (data.status === 'finish') {
+        this.pollingSubscription?.unsubscribe();
+      }
+    });
+  }
+}

--- a/src/app/question/question.component.html
+++ b/src/app/question/question.component.html
@@ -1,13 +1,16 @@
-@if (question) {
-  <h2>問題</h2>
+@if (question(); as question) {
+  <h2>問題{{ question.questionId }}</h2>
   <img [src]="question.imageUrl" />
   <h2>選択肢</h2>
   @for (choice of question.choices; track choice.choiceId) {
-    <button (click)="sendAnswer(choice.choiceId)">
+    <button (click)="sendAnswer(choice.choiceId)" [disabled]="!isOpen()">
       {{ choice.choiceId }}：{{ choice.text }}
     </button>
   }
   @if (result) {
     <div>{{ result }}</div>
+  }
+  @if (!isOpen()) {
+    <div>回答を締め切りました</div>
   }
 }

--- a/src/app/service/api.interface.ts
+++ b/src/app/service/api.interface.ts
@@ -38,6 +38,10 @@ export type Choice = {
   text: string;
 };
 
+export type Status =
+  | { status: 'waiting' | 'finish' }
+  | { status: 'open' | 'close'; questionId: number };
+
 export type ApiError = {
   error: { code: number; message: string };
 };

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -11,6 +11,7 @@ import {
   SignInRes,
   SignUpReq,
   SignUpRes,
+  Status,
 } from './api.interface';
 
 @Injectable({
@@ -61,6 +62,11 @@ export class ApiService {
   /** 問題送信 */
   postAnswer(questionId: number, data: PostQuestionAnswerReq) {
     return this.post('/questions/' + questionId + '/answer', data);
+  }
+
+  /** ステータス取得 */
+  getStatus() {
+    return this.get<Status>('/status');
   }
 
   /** 認証付きGETリクエスト */


### PR DESCRIPTION
## 変更点

- トップページで GET /status をポーリングするように変更
- トップページでは PlayerComponent を表示するように変更

## 動作確認

- [x] トップページにアクセスしたときに、問題1がでる（回答はできない）
- [x] 3秒おきにポーリングされている（リクエスト回数を減らすために一旦3秒に設定。本番はもうちょっと短くするかも）