### PR TITLE
👍 管理画面のステータス送信処理を実装

### DIFF
--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -4,8 +4,8 @@
   </div>
 
   <div>
-    <input placeholder="question_id" />
-    <button>問題出題</button>
+    <input placeholder="question_id" [(ngModel)]="questionId" />
+    <button (click)="sendStatus('open', questionId)">問題出題</button>
   </div>
 
   <div>

--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -4,15 +4,12 @@
   </div>
 
   <div>
-    <div>
-      <input placeholder="question_id" [(ngModel)]="questionId" />
-      <button (click)="sendStatus('open', questionId)">問題出題</button>
-    </div>
+    <input placeholder="question_id" [(ngModel)]="questionId" />
+  </div>
 
-    <div>
-      <input placeholder="question_id" [(ngModel)]="questionId" />
-      <button (click)="sendStatus('close', questionId)">回答締め切り</button>
-    </div>
+  <div class="question-buttons">
+    <button (click)="sendStatus('close', questionId)">回答締め切り</button>
+    <button (click)="sendStatus('open', questionId)">問題出題</button>
   </div>
 
   <div>

--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -1,6 +1,6 @@
 <div>
   <div>
-    <button>待機</button>
+    <button (click)="sendStatus('waiting')">待機</button>
   </div>
 
   <div>

--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -15,4 +15,8 @@
   <div>
     <button>ゲーム終了</button>
   </div>
+
+  @if (result) {
+    <div>{{ result }}</div>
+  }
 </div>

--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -4,12 +4,15 @@
   </div>
 
   <div>
-    <input placeholder="question_id" [(ngModel)]="questionId" />
-    <button (click)="sendStatus('open', questionId)">問題出題</button>
-  </div>
+    <div>
+      <input placeholder="question_id" [(ngModel)]="questionId" />
+      <button (click)="sendStatus('open', questionId)">問題出題</button>
+    </div>
 
-  <div>
-    <button>回答終了</button>
+    <div>
+      <input placeholder="question_id" [(ngModel)]="questionId" />
+      <button (click)="sendStatus('close', questionId)">回答締め切り</button>
+    </div>
   </div>
 
   <div>

--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -13,7 +13,7 @@
   </div>
 
   <div>
-    <button>ゲーム終了</button>
+    <button (click)="sendStatus('finish')">ゲーム終了</button>
   </div>
 
   @if (result) {

--- a/src/app/control/status/status.component.scss
+++ b/src/app/control/status/status.component.scss
@@ -1,0 +1,5 @@
+.question-buttons {
+    display: flex;
+    padding: 8px 0;
+    gap: 8px;
+}

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ApiService } from '../../service/api.service';
 
 @Component({
   selector: 'app-status',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './status.component.html',
   styleUrl: './status.component.scss',
 })
-export class StatusComponent {}
+export class StatusComponent {
+  api = inject(ApiService);
+
+  sendStatus(status: string, questionId?: number) {
+    if (status === 'open' && questionId === undefined) return;
+
+    this.api.postStatus({ status, questionId });
+  }
+}

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -13,14 +13,41 @@ export class StatusComponent {
   result: string | undefined;
 
   sendStatus(status: string, questionId?: number) {
-    if (status === 'open' && questionId === null) return;
+    switch (status) {
+      case 'waiting':
+        break;
+      case 'open':
+        if (questionId === undefined) return;
+        break;
+      case 'close':
+        if (questionId === undefined) return;
+        break;
+      case 'finish':
+        break;
+      default:
+        return;
+    }
 
     this.api.postStatus({ status, questionId }).subscribe((data) => {
       if (isApiError(data)) {
         this.result = `${data.error.message} (${data.error.code})`;
         return;
       }
-      this.result = 'ステータスを「待機中」に設定しました';
+
+      switch (status) {
+        case 'waiting':
+          this.result = 'ステータスを「待機中」に設定しました';
+          break;
+        case 'open':
+          this.result = `問題${questionId}を出題しました`;
+          break;
+        case 'close':
+          this.result = `問題${questionId}の回答を締め切りました`;
+          break;
+        case 'finish':
+          this.result = 'ステータスを「終了」に設定しました';
+          break;
+      }
     });
   }
 }

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { ApiService } from '../../service/api.service';
+import { ApiService, isApiError } from '../../service/api.service';
 
 @Component({
   selector: 'app-status',
@@ -10,9 +10,17 @@ import { ApiService } from '../../service/api.service';
 export class StatusComponent {
   api = inject(ApiService);
 
-  sendStatus(status: string, questionId?: number) {
-    if (status === 'open' && questionId === undefined) return;
+  result: string | undefined;
 
-    this.api.postStatus({ status, questionId });
+  sendStatus(status: string, questionId?: number) {
+    if (status === 'open' && questionId === null) return;
+
+    this.api.postStatus({ status, questionId }).subscribe((data) => {
+      if (isApiError(data)) {
+        this.result = `${data.error.message} (${data.error.code})`;
+        return;
+      }
+      this.result = 'ステータスを「待機中」に設定しました';
+    });
   }
 }

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -1,9 +1,10 @@
 import { Component, inject } from '@angular/core';
 import { ApiService, isApiError } from '../../service/api.service';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-status',
-  imports: [],
+  imports: [FormsModule],
   templateUrl: './status.component.html',
   styleUrl: './status.component.scss',
 })
@@ -12,7 +13,9 @@ export class StatusComponent {
 
   result: string | undefined;
 
-  sendStatus(status: string, questionId?: number) {
+  questionId: string | undefined;
+
+  sendStatus(status: string, questionId?: string) {
     switch (status) {
       case 'waiting':
         break;
@@ -28,26 +31,32 @@ export class StatusComponent {
         return;
     }
 
-    this.api.postStatus({ status, questionId }).subscribe((data) => {
-      if (isApiError(data)) {
-        this.result = `${data.error.message} (${data.error.code})`;
-        return;
-      }
+    // string から number に変換
+    const parseQuestionId =
+      questionId === undefined ? undefined : parseInt(questionId!);
 
-      switch (status) {
-        case 'waiting':
-          this.result = 'ステータスを「待機中」に設定しました';
-          break;
-        case 'open':
-          this.result = `問題${questionId}を出題しました`;
-          break;
-        case 'close':
-          this.result = `問題${questionId}の回答を締め切りました`;
-          break;
-        case 'finish':
-          this.result = 'ステータスを「終了」に設定しました';
-          break;
-      }
-    });
+    this.api
+      .postStatus({ status, questionId: parseQuestionId })
+      .subscribe((data) => {
+        if (isApiError(data)) {
+          this.result = `${data.error.message} (${data.error.code})`;
+          return;
+        }
+
+        switch (status) {
+          case 'waiting':
+            this.result = 'ステータスを「待機中」に設定しました';
+            break;
+          case 'open':
+            this.result = `問題${questionId}を出題しました`;
+            break;
+          case 'close':
+            this.result = `問題${questionId}の回答を締め切りました`;
+            break;
+          case 'finish':
+            this.result = 'ステータスを「終了」に設定しました';
+            break;
+        }
+      });
   }
 }

--- a/src/app/service/api.interface.ts
+++ b/src/app/service/api.interface.ts
@@ -33,6 +33,11 @@ export type Choice = {
   text: string;
 };
 
+export type PostStatusReq = {
+  status: string;
+  questionId?: number;
+};
+
 export type ApiError = {
   error: { code: number; message: string };
 };

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -6,6 +6,7 @@ import {
   ApiError,
   GetQuestionRes,
   PostQuestionAnswerReq,
+  PostStatusReq,
   SignInReq,
   SignInRes,
   SignUpReq,
@@ -50,6 +51,11 @@ export class ApiService {
   /** 問題送信 */
   postAnswer(questionId: number, data: PostQuestionAnswerReq) {
     return this.post('/questions/' + questionId + '/answer', data);
+  }
+
+  /** ステータス送信 */
+  postStatus(data: PostStatusReq) {
+    return this.post('/status', data);
   }
 
   /** 認証付きGETリクエスト */

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -82,5 +82,5 @@ export class ApiService {
 }
 
 export function isApiError(data: any): data is ApiError {
-  return 'error' in data;
+  return data && 'error' in data;
 }


### PR DESCRIPTION
## 変更点
- 管理画面のステータス画面でボタンをクリックしたときにステータスを送信
- 一部UIを変更

## 動作確認
- [x] 「待機」をクリック、`POST /status`に`{'status': 'waiting'}`が送信されることが確認できる
- [x]  フォームに`question_id`を入力して「問題出題」をクリック、`POST /status`に`{'status': 'open', 'questionId': 入力内容}`が送信されることが確認できる
- [x] フォームに`question_id`を入力して「回答締め切り」をクリック、`POST /status`に`{'status': 'close', 'questionId': 入力内容}`が送信されることが確認できる
- [x] フォームに何も入力してない時にそれぞれのボタンをクリックした時、APIアクセスが発生しない
- [x] 「ゲーム終了」をクリック、`POST /status`に`{'status': 'finish'}`が送信されることが確認できる
- [x] それぞれのボタンをクリックしてリクエストに成功した時、メッセージが表示される
