### PR TITLE
👍 ログイン状態に応じて見れるパスを制限

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,4 @@
-import { Routes } from '@angular/router';
+import { CanActivateFn, Router, Routes } from '@angular/router';
 import { SignupComponent } from './signup/signup.component';
 import { SigninComponent } from './signin/signin.component';
 import { FinishComponent } from './finish/finish.component';
@@ -8,9 +8,72 @@ import { RegisterComponent } from './control/register/register.component';
 import { StatusComponent } from './control/status/status.component';
 import { PlayerComponent } from './player/player.component';
 import { ProjectorComponent } from './projector/projector.component';
+import { inject } from '@angular/core';
+import { UserService } from './service/user.service';
+import { mergeMap, of } from 'rxjs';
+
+const adminGuard: CanActivateFn = () => {
+  const userService = inject(UserService);
+  return userService.update().pipe(
+    mergeMap((data) => {
+      if (data?.role === 'ADMIN') return of(true);
+      else return of(false);
+    }),
+  );
+};
+
+const loginGuard: CanActivateFn = () => {
+  const userService = inject(UserService);
+  const router = inject(Router);
+  return userService.update().pipe(
+    mergeMap((data) => {
+      console.log(data);
+      if (data) return of(true);
+      else {
+        return of(router.parseUrl('signup'));
+      }
+    }),
+  );
+};
 
 export const routes: Routes = [
-  { path: '', component: PlayerComponent },
+  {
+    path: '',
+    canActivate: [loginGuard],
+    children: [
+      {
+        path: '',
+        component: PlayerComponent,
+      },
+      {
+        path: 'finish',
+        component: FinishComponent,
+      },
+      {
+        path: 'waiting',
+        component: WaitingComponent,
+      },
+      {
+        path: 'control',
+        component: ControlComponent,
+        canActivate: [adminGuard],
+        children: [
+          {
+            path: 'register',
+            component: RegisterComponent,
+          },
+          {
+            path: 'status',
+            component: StatusComponent,
+          },
+        ],
+      },
+      {
+        path: 'projector',
+        component: ProjectorComponent,
+      },
+    ],
+  },
   {
     path: 'signup',
     component: SignupComponent,
@@ -18,31 +81,5 @@ export const routes: Routes = [
   {
     path: 'signin',
     component: SigninComponent,
-  },
-  {
-    path: 'finish',
-    component: FinishComponent,
-  },
-  {
-    path: 'waiting',
-    component: WaitingComponent,
-  },
-  {
-    path: 'control',
-    component: ControlComponent,
-    children: [
-      {
-        path: 'register',
-        component: RegisterComponent,
-      },
-      {
-        path: 'status',
-        component: StatusComponent,
-      },
-    ],
-  },
-  {
-    path: 'projector',
-    component: ProjectorComponent,
   },
 ];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -82,4 +82,5 @@ export const routes: Routes = [
     path: 'signin',
     component: SigninComponent,
   },
+  { path: '**', redirectTo: '/' },
 ];

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <header>
   @if (this.userService.user() !== undefined) {
     @if (this.userService.user(); as user) {
-      <div class="username">{{ user.username }}</div>
+      <div class="username">{{ user.username }}（{{ user.role }}）</div>
       <button class="logout" (click)="signout()">ログアウト</button>
     } @else {
       <a [routerLink]="'signup'">新規登録</a>

--- a/src/app/service/user.service.ts
+++ b/src/app/service/user.service.ts
@@ -1,4 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
+import { mergeMap, of } from 'rxjs';
 import { ApiService, isApiError } from './api.service';
 
 export type User = {
@@ -18,16 +19,23 @@ export class UserService {
 
   constructor() {
     // 初期化時にログイン状態を確認
-    this.update();
+    this.update().subscribe();
   }
 
   /** ユーザー情報更新 */
   update() {
     // エラーだったら未ログイン、データが帰ってきたらログイン済み
-    this.api.getMe().subscribe((data) => {
-      if (isApiError(data)) this.user.set(null);
-      else this.user.set(data);
-    });
+    return this.api.getMe().pipe(
+      mergeMap((data) => {
+        if (isApiError(data)) {
+          this.user.set(null);
+          return of(undefined);
+        } else {
+          this.user.set(data);
+          return of(data);
+        }
+      }),
+    );
   }
 
   /** サインアウト */

--- a/src/app/signin/signin.component.ts
+++ b/src/app/signin/signin.component.ts
@@ -33,7 +33,7 @@ export class SigninComponent {
         return;
       }
       this.result = 'ログインに成功しました⭐️';
-      this.userService.update();
+      this.userService.update().subscribe();
     });
   }
 }

--- a/src/app/signup/signup.component.ts
+++ b/src/app/signup/signup.component.ts
@@ -35,7 +35,7 @@ export class SignupComponent {
         return;
       }
       this.result = data.username + ' で新規登録が完了しました🎉';
-      this.userService.update();
+      this.userService.update().subscribe();
     });
   }
 }


### PR DESCRIPTION
##  変更点

- ヘッダーにロールを表示するようにしました。
  - 動作確認が楽なので、一時的なものでいずれ削除する予定です
- ログインしていないと問題画面に入れないようになりました（新規登録に誘導される）
- ADMINアカウントでログインしていないと管理画面に入れないようになりました

## 動作確認

- [x] 未ログイン時にトップにアクセスすると新規登録画面に誘導される
  - [x] /finish などにアクセスしても新規登録画面に誘導される
- [x] 通常ユーザーでログインしてトップにアクセスすると現在のステータスに応じた画面が出る
  - [x] /control にはアクセスできない
- [x] ADMINユーザーでログインしてトップにアクセスすると現在のステータスに応じた画面が出る
  - [x] /control も見れる