### PR TITLE
👍 管理画面の調整

### DIFF
--- a/src/app/control/control.component.html
+++ b/src/app/control/control.component.html
@@ -1,11 +1,13 @@
 <div>
   <div>
-    <a [routerLink]="'register'">問題登録</a>
+    <h2>問題登録</h2>
+    <app-register></app-register>
   </div>
+
+  <hr />
 
   <div>
-    <a [routerLink]="'status'">ステータス管理</a>
+    <h2>ステータス管理</h2>
+    <app-status></app-status>
   </div>
 </div>
-
-<router-outlet />

--- a/src/app/control/control.component.ts
+++ b/src/app/control/control.component.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterOutlet } from '@angular/router';
+import { RegisterComponent } from './register/register.component';
+import { StatusComponent } from './status/status.component';
 
 @Component({
   selector: 'app-control',
-  imports: [RouterLink, RouterOutlet],
+  imports: [RegisterComponent, StatusComponent],
   templateUrl: './control.component.html',
   styleUrl: './control.component.scss',
 })

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -31,6 +31,9 @@ export class StatusComponent {
         return;
     }
 
+    if (status === 'finish' && !window.confirm('ゲームを終了しますか？'))
+      return;
+
     // string から number に変換
     const parseQuestionId =
       questionId === undefined ? undefined : parseInt(questionId!);


### PR DESCRIPTION
## 変更点
- ステータス管理で「終了」に設定するとき、確認を取るようにした
- リンクではなく直接コンポーネントを表示するように変更

## 動作確認
- [x] adminでログインする
- [x] 管理画面に移動する。リンクが表示されず、問題登録とステータス管理のUIが表示されている
- [x] ステータス管理の「ゲーム終了」をクリックする。ダイアログが表示され、OKをクリックしたときだけステータスが「終了」になる
