### PR TITLE
👍 問題登録の処理を追加

### DIFF
--- a/src/app/control/register/register.component.html
+++ b/src/app/control/register/register.component.html
@@ -1,50 +1,52 @@
-<form>
+<form class="form" [formGroup]="formData" (ngSubmit)="register()">
   <div>
     <label>
       問題ID
-      <input />
+      <input [formControlName]="'questionId'" />
     </label>
   </div>
 
   <div>
     <label>
       画像URL
-      <input />
+      <input [formControlName]="'imageUrl'" />
     </label>
   </div>
 
-  <div>
-    <label>
-      選択肢1
-      <input />
-    </label>
-  </div>
+  <div [formGroup]="choices">
+    <div>
+      <label>
+        選択肢1
+        <input [formControlName]="'choice_1'" />
+      </label>
+    </div>
 
-  <div>
-    <label>
-      選択肢2
-      <input />
-    </label>
-  </div>
+    <div>
+      <label>
+        選択肢2
+        <input [formControlName]="'choice_2'" />
+      </label>
+    </div>
 
-  <div>
-    <label>
-      選択肢3
-      <input />
-    </label>
-  </div>
+    <div>
+      <label>
+        選択肢3
+        <input [formControlName]="'choice_3'" />
+      </label>
+    </div>
 
-  <div>
-    <label>
-      選択肢4
-      <input />
-    </label>
+    <div>
+      <label>
+        選択肢4
+        <input [formControlName]="'choice_4'" />
+      </label>
+    </div>
   </div>
 
   <div>
     <label>
       正解
-      <select>
+      <select [formControlName]="'correctChoiceId'">
         <option value=""></option>
         <option value="1">1</option>
         <option value="2">2</option>
@@ -56,3 +58,7 @@
 
   <button>登録</button>
 </form>
+
+@if (result) {
+  <div>{{ result }}</div>
+}

--- a/src/app/control/register/register.component.ts
+++ b/src/app/control/register/register.component.ts
@@ -1,9 +1,58 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ApiService, isApiError } from '../../service/api.service';
+import {
+  FormArray,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+} from '@angular/forms';
 
 @Component({
   selector: 'app-register',
-  imports: [],
+  imports: [ReactiveFormsModule],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
 })
-export class RegisterComponent {}
+export class RegisterComponent {
+  api = inject(ApiService);
+
+  formData = new FormGroup({
+    questionId: new FormControl(''),
+    imageUrl: new FormControl(''),
+    choices: new FormGroup({
+      choice_1: new FormControl(''),
+      choice_2: new FormControl(''),
+      choice_3: new FormControl(''),
+      choice_4: new FormControl(''),
+    }),
+    correctChoiceId: new FormControl(''),
+  });
+
+  result = '';
+
+  register() {
+    const data = {
+      questionId: parseInt(this.formData.value.questionId!),
+      imageUrl: this.formData.value.imageUrl ?? '',
+      choices: [
+        { choiceId: 1, text: this.formData.value.choices?.choice_1 ?? '' },
+        { choiceId: 2, text: this.formData.value.choices?.choice_2 ?? '' },
+        { choiceId: 3, text: this.formData.value.choices?.choice_3 ?? '' },
+        { choiceId: 4, text: this.formData.value.choices?.choice_4 ?? '' },
+      ],
+      correctChoiceId: parseInt(this.formData.value.correctChoiceId!),
+    };
+
+    this.api.postQuestion(data).subscribe((data) => {
+      if (isApiError(data)) {
+        this.result = `問題の登録に失敗しました。${data.error.message} (${data.error.code})`;
+        return;
+      }
+      this.result = '問題を登録しました';
+    });
+  }
+
+  get choices(): FormGroup {
+    return this.formData.get('choices') as FormGroup;
+  }
+}

--- a/src/app/control/register/register.component.ts
+++ b/src/app/control/register/register.component.ts
@@ -30,7 +30,28 @@ export class RegisterComponent {
 
   result = '';
 
+  private check() {
+    if (
+      !this.formData.value.questionId ||
+      !this.formData.value.choices?.choice_1 ||
+      !this.formData.value.choices?.choice_2 ||
+      !this.formData.value.choices?.choice_3 ||
+      !this.formData.value.choices?.choice_4 ||
+      !this.formData.value.correctChoiceId
+    ) {
+      this.result = '入力していない項目があります';
+      return false;
+    }
+
+    return true;
+  }
+
   register() {
+    // すべての項目が入力されているかチェック
+    if (!this.check()) {
+      return;
+    }
+
     const data = {
       questionId: parseInt(this.formData.value.questionId!),
       imageUrl: this.formData.value.imageUrl ?? '',

--- a/src/app/service/api.interface.ts
+++ b/src/app/service/api.interface.ts
@@ -43,6 +43,13 @@ export type PostStatusReq = {
   questionId?: number;
 };
 
+export type PostQuestionReq = {
+  questionId: number;
+  imageUrl: string;
+  choices: Choice[];
+  correctChoiceId: number;
+};
+
 export type Status =
   | { status: 'waiting' | 'finish' }
   | { status: 'open' | 'close'; questionId: number };

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -7,6 +7,7 @@ import {
   GetMeRes,
   GetQuestionRes,
   PostQuestionAnswerReq,
+  PostQuestionReq,
   PostStatusReq,
   SignInReq,
   SignInRes,
@@ -73,6 +74,11 @@ export class ApiService {
   /** ステータス取得 */
   getStatus() {
     return this.get<Status>('/status');
+  }
+
+  /** 問題の登録（管理画面） */
+  postQuestion(data: PostQuestionReq) {
+    return this.post('/questions', data);
   }
 
   /** 認証付きGETリクエスト */


### PR DESCRIPTION
## 変更内容
- 問題登録用のインターフェースとAPIサービスを追加
- 問題登録処理を追加

## 動作確認
- [x] adminでログインする
- [x] 管理画面の問題登録からすべての項目を入力して「登録」をクリックする。問題の登録ができる
- [x] すべての項目を**入力していない状態で**「登録」をクリックする。`POST /questions`のAPIアクセスが発生せず、画面に「入力していない項目があります」と表示される