### PR TITLE
🐛 回答画面の画像が表示されなかった問題を修正

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -12,6 +12,9 @@
         },
         "@schematics/angular:service": {
           "skipTests": true
+        },
+        "@schematics/angular:directive": {
+          "skipTests": true
         }
       },
       "root": "",

--- a/src/app/directive/auth-image.directive.ts
+++ b/src/app/directive/auth-image.directive.ts
@@ -1,0 +1,31 @@
+import { Directive, effect, ElementRef, inject, input } from '@angular/core';
+import { ApiService } from '../service/api.service';
+import ENV from '../../environments/environment.json';
+
+/**
+ * 画像のリクエストに Authorization ヘッダを付与するためのディレクティブ
+ * 外部へのアクセスの場合はそのまま表示する
+ */
+@Directive({
+  selector: 'img[appAuthSrc]',
+})
+export class AuthImageDirective {
+  el = inject<ElementRef<HTMLImageElement>>(ElementRef);
+  apiService = inject(ApiService);
+
+  appAuthSrc = input.required<string>();
+
+  constructor() {
+    effect(() => {
+      const url = this.appAuthSrc();
+      // サーバー以外へのアクセスならそのまま表示（トークンを送らないようにするため）
+      if (!url.includes(ENV.API_BASE)) {
+        this.el.nativeElement.src = url;
+        return;
+      }
+      this.apiService.getImage(url).subscribe((res) => {
+        this.el.nativeElement.src = URL.createObjectURL(res);
+      });
+    });
+  }
+}

--- a/src/app/question/question.component.html
+++ b/src/app/question/question.component.html
@@ -1,6 +1,6 @@
 @if (question(); as question) {
   <h2>問題{{ question.questionId }}</h2>
-  <img [appAuthSrc]="question.imageUrl" />
+  <img [appAuthSrc]="question.imageUrl" [alt]="'問題画像'" />
   <h2>選択肢</h2>
   @for (choice of question.choices; track choice.choiceId) {
     <button (click)="sendAnswer(choice.choiceId)" [disabled]="!isOpen()">

--- a/src/app/question/question.component.html
+++ b/src/app/question/question.component.html
@@ -1,6 +1,6 @@
 @if (question(); as question) {
   <h2>問題{{ question.questionId }}</h2>
-  <img [src]="question.imageUrl" />
+  <img [appAuthSrc]="question.imageUrl" />
   <h2>選択肢</h2>
   @for (choice of question.choices; track choice.choiceId) {
     <button (click)="sendAnswer(choice.choiceId)" [disabled]="!isOpen()">

--- a/src/app/question/question.component.ts
+++ b/src/app/question/question.component.ts
@@ -8,10 +8,11 @@ import {
 } from '@angular/core';
 import { ApiService, isApiError } from '../service/api.service';
 import { GetQuestionRes, Status } from '../service/api.interface';
+import { AuthImageDirective } from '../directive/auth-image.directive';
 
 @Component({
   selector: 'app-question',
-  imports: [],
+  imports: [AuthImageDirective],
   templateUrl: './question.component.html',
   styleUrl: './question.component.scss',
 })

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -75,6 +75,13 @@ export class ApiService {
     return this.get<Status>('/status');
   }
 
+  getImage(url: string) {
+    return this.httpClient.get(url, {
+      headers: { Authorization: `Bearer ${this.getToken()}` },
+      responseType: 'blob',
+    });
+  }
+
   /** 認証付きGETリクエスト */
   private get<T = {}>(path: string) {
     return this.httpClient.get<T | ApiError>(this.baseUrl + path, {


### PR DESCRIPTION
## 変更点

回答問題の画像のアクセスにAuthorizationヘッダが必要だったため、Angular のDirective を用いて、画像の取得を行うようにしました。

## 動作確認

- [x] 回答画面の画像が表示されている