### PR TITLE
👍 /me を重複して叩かないように getUser 関数を追加

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -14,7 +14,7 @@ import { mergeMap, of } from 'rxjs';
 
 const adminGuard: CanActivateFn = () => {
   const userService = inject(UserService);
-  return userService.update().pipe(
+  return userService.getUser().pipe(
     mergeMap((data) => {
       if (data?.role === 'ADMIN') return of(true);
       else return of(false);
@@ -25,9 +25,8 @@ const adminGuard: CanActivateFn = () => {
 const loginGuard: CanActivateFn = () => {
   const userService = inject(UserService);
   const router = inject(Router);
-  return userService.update().pipe(
+  return userService.getUser().pipe(
     mergeMap((data) => {
-      console.log(data);
       if (data) return of(true);
       else {
         return of(router.parseUrl('signup'));

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -17,7 +17,7 @@ export class HeaderComponent {
   signout() {
     this.userService.signout();
     this.router.navigate(['/']).then(() => {
-    window.location.reload();
+      window.location.reload();
     });
   }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -16,7 +16,8 @@ export class HeaderComponent {
 
   signout() {
     this.userService.signout();
-    this.router.navigate(['/']);
+    this.router.navigate(['/']).then(() => {
     window.location.reload();
+    });
   }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -16,8 +16,6 @@ export class HeaderComponent {
 
   signout() {
     this.userService.signout();
-    this.router.navigate(['/']).then(() => {
-      window.location.reload();
-    });
+    window.location.href = '/';
   }
 }

--- a/src/app/service/user.service.ts
+++ b/src/app/service/user.service.ts
@@ -14,28 +14,27 @@ export type User = {
 export class UserService {
   api = inject(ApiService);
 
-  /** ユーザー情報　undefined: 初期化前、null: 未ログイン */
+  /** ユーザー情報 undefined: 初期化前、null: 未ログイン */
   user = signal<User | undefined | null>(undefined);
 
-  constructor() {
-    // 初期化時にログイン状態を確認
-    this.update().subscribe();
-  }
-
-  /** ユーザー情報更新 */
-  update() {
-    // エラーだったら未ログイン、データが帰ってきたらログイン済み
-    return this.api.getMe().pipe(
-      mergeMap((data) => {
-        if (isApiError(data)) {
-          this.user.set(null);
-          return of(undefined);
-        } else {
-          this.user.set(data);
-          return of(data);
-        }
-      }),
-    );
+  /** ユーザー情報取得。取得済みであればそれを返し、未取得であればAPIリクエストする */
+  getUser() {
+    console.log('getUser');
+    const user = this.user();
+    if (user !== undefined) return of(user);
+    else {
+      return this.api.getMe().pipe(
+        mergeMap((data) => {
+          if (isApiError(data)) {
+            this.user.set(null);
+            return of(null);
+          } else {
+            this.user.set(data);
+            return of(data);
+          }
+        }),
+      );
+    }
   }
 
   /** サインアウト */

--- a/src/app/signin/signin.component.ts
+++ b/src/app/signin/signin.component.ts
@@ -35,9 +35,7 @@ export class SigninComponent {
         return;
       }
       this.result = 'ログインに成功しました⭐️';
-      this.router.navigate(['/']).then(() => {
-        window.location.reload();
-      });
+      window.location.href = '/';
     });
   }
 }

--- a/src/app/signin/signin.component.ts
+++ b/src/app/signin/signin.component.ts
@@ -35,8 +35,9 @@ export class SigninComponent {
         return;
       }
       this.result = 'ログインに成功しました⭐️';
-      this.userService.update().subscribe();
-      this.router.navigate(['/']);
+      this.router.navigate(['/']).then(() => {
+        window.location.reload();
+      });
     });
   }
 }

--- a/src/app/signup/signup.component.ts
+++ b/src/app/signup/signup.component.ts
@@ -37,9 +37,7 @@ export class SignupComponent {
         return;
       }
       this.result = data.username + ' で新規登録が完了しました🎉';
-      this.router.navigate(['/']).then(() => {
-        window.location.reload();
-      });
+      window.location.href = '/';
     });
   }
 }

--- a/src/app/signup/signup.component.ts
+++ b/src/app/signup/signup.component.ts
@@ -37,8 +37,9 @@ export class SignupComponent {
         return;
       }
       this.result = data.username + ' で新規登録が完了しました🎉';
-      this.userService.update().subscribe();
-      this.router.navigate(['/']);
+      this.router.navigate(['/']).then(() => {
+        window.location.reload();
+      });
     });
   }
 }


### PR DESCRIPTION
## 変更点

- 新規登録・ログイン・ログアウト時にリロードするようにしました
- getUser 関数を追加し、すでにuser情報があるならその情報を返し、情報がないなら `/me` を叩くようにしました。
  - これにより、canActivate で loginGuard と adminGuard の両方で /me を叩かないようになりました

## 動作確認

- [x] 新規登録・ログイン・ログアウト時にリロードされ、リロード後はログイン状態が正しく反映されている
- [x] 管理者にてログイン状態で/control にアクセスして、リロードしても、/me が複数回叩かれていない