### PR TITLE
👍 ヘッダーを整理

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@angular/platform-browser": "^19.0.0",
     "@angular/platform-browser-dynamic": "^19.0.0",
     "@angular/router": "^19.0.0",
+    "@ng-icons/core": "^29.10.0",
+    "@ng-icons/font-awesome": "^29.10.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,13 +2,5 @@
   <app-header />
   <h1><a href="/">QuizWeb</a></h1>
 
-  <div>
-    <a [routerLink]="'/control'">管理画面</a>
-  </div>
-
-  <div>
-    <a [routerLink]="'/projector'">プロジェクター用</a>
-  </div>
-
   <router-outlet />
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,7 @@
 <div class="container" [class.mobile-layout]="isMobileLayout()">
-  <app-header />
+  @if (!isProjector()) {
+    <app-header />
+  }
   <h1><a href="/">QuizWeb</a></h1>
 
   <router-outlet />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,17 +1,12 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import {
-  NavigationEnd,
-  Router,
-  RouterLink,
-  RouterOutlet,
-} from '@angular/router';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './header/header.component';
 import { filter } from 'rxjs';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, ReactiveFormsModule, RouterLink, HeaderComponent],
+  imports: [RouterOutlet, ReactiveFormsModule, HeaderComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,6 +14,7 @@ export class AppComponent implements OnInit {
   router = inject(Router);
 
   isMobileLayout = signal(true);
+  isProjector = signal(false);
 
   ngOnInit() {
     // 管理画面等は幅を制限しない
@@ -25,6 +26,12 @@ export class AppComponent implements OnInit {
           this.isMobileLayout.set(false);
         } else {
           this.isMobileLayout.set(true);
+        }
+
+        if (url.includes('projector')) {
+          this.isProjector.set(true);
+        } else {
+          this.isProjector.set(false);
         }
       });
   }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,11 +1,28 @@
 <header>
+  @if (isAdmin()) {
+    <div class="links">
+      <a class="link" [routerLink]="'/control'">
+        <ng-icon name="faSolidScrewdriverWrench" />
+        <span>管理画面</span>
+      </a>
+
+      <a class="link" [routerLink]="'/projector'">
+        <ng-icon name="faSolidDisplay" />
+        <span>プロジェクター用</span>
+      </a>
+    </div>
+  }
+  <div class="spacer"></div>
+
   @if (this.userService.user() !== undefined) {
-    @if (this.userService.user(); as user) {
-      <div class="username">{{ user.username }}（{{ user.role }}）</div>
-      <button class="logout" (click)="signout()">ログアウト</button>
-    } @else {
-      <a [routerLink]="'signup'">新規登録</a>
-      <a [routerLink]="'signin'">ログイン</a>
-    }
+    <div>
+      @if (this.userService.user(); as user) {
+        <div class="username">{{ user.username }}（{{ user.role }}）</div>
+        <button class="logout" (click)="signout()">ログアウト</button>
+      } @else {
+        <a [routerLink]="'signup'">新規登録</a>
+        <a [routerLink]="'signin'">ログイン</a>
+      }
+    </div>
   }
 </header>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -14,19 +14,14 @@
   }
   <div class="spacer"></div>
 
-  @if (this.userService.user() !== undefined) {
+  @if (this.userService.user(); as user) {
     <div>
-      @if (this.userService.user(); as user) {
-        <div class="username" (dblclick)="signout()">
-          <span>{{ user.username }}</span>
-          @if (user.role === "ADMIN") {
-            <span class="role">管理者</span>
-          }
-        </div>
-      } @else {
-        <a [routerLink]="'signup'">新規登録</a>
-        <a [routerLink]="'signin'">ログイン</a>
-      }
+      <div class="username" (dblclick)="signout()">
+        <span>{{ user.username }}</span>
+        @if (user.role === "ADMIN") {
+          <span class="role">管理者</span>
+        }
+      </div>
     </div>
   }
 </header>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -18,7 +18,10 @@
     <div>
       @if (this.userService.user(); as user) {
         <div class="username" (dblclick)="signout()">
-          {{ user.username }}（{{ user.role }}）
+          <span>{{ user.username }}</span>
+          @if (user.role === "ADMIN") {
+            <span class="role">管理者</span>
+          }
         </div>
       } @else {
         <a [routerLink]="'signup'">新規登録</a>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -17,8 +17,9 @@
   @if (this.userService.user() !== undefined) {
     <div>
       @if (this.userService.user(); as user) {
-        <div class="username">{{ user.username }}（{{ user.role }}）</div>
-        <button class="logout" (click)="signout()">ログアウト</button>
+        <div class="username" (dblclick)="signout()">
+          {{ user.username }}（{{ user.role }}）
+        </div>
       } @else {
         <a [routerLink]="'signup'">新規登録</a>
         <a [routerLink]="'signin'">ログイン</a>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -24,3 +24,14 @@ header {
 .spacer {
   flex: 1;
 }
+
+.username {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: right;
+
+  .role {
+    font-size: 12px;
+  }
+}

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -1,0 +1,26 @@
+header {
+  padding: 8px 16px;
+  display: flex;
+}
+
+.links {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .link {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  ng-icon {
+    height: 24px;
+    width: 24px;
+    line-height: 1;
+  }
+}
+
+.spacer {
+  flex: 1;
+}

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,11 +1,17 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { UserService } from '../service/user.service';
 import { Router, RouterLink } from '@angular/router';
 import { ApiService } from '../service/api.service';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  faSolidDisplay,
+  faSolidScrewdriverWrench,
+} from '@ng-icons/font-awesome/solid';
 
 @Component({
   selector: 'app-header',
-  imports: [RouterLink],
+  imports: [RouterLink, NgIcon],
+  viewProviders: [provideIcons({ faSolidScrewdriverWrench, faSolidDisplay })],
   templateUrl: './header.component.html',
   styleUrl: './header.component.scss',
 })
@@ -13,6 +19,10 @@ export class HeaderComponent {
   router = inject(Router);
   apiService = inject(ApiService);
   userService = inject(UserService);
+
+  isAdmin = computed(() => {
+    return this.userService.user()?.role === 'ADMIN';
+  });
 
   signout() {
     this.userService.signout();

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -25,8 +25,10 @@ export class HeaderComponent {
   });
 
   signout() {
-    this.userService.signout();
-    this.router.navigate(['/']);
-    window.location.reload();
+    if (window.confirm('サインアウトしますか？')) {
+      this.userService.signout();
+      this.router.navigate(['/']);
+      window.location.reload();
+    }
   }
 }

--- a/src/app/signin/signin.component.html
+++ b/src/app/signin/signin.component.html
@@ -15,3 +15,7 @@
 @if (result) {
   <div>{{ result }}</div>
 }
+
+<div class="signup-link">
+  <a [routerLink]="'/signup'">まだアカウントをお持ちでない方</a>
+</div>

--- a/src/app/signin/signin.component.scss
+++ b/src/app/signin/signin.component.scss
@@ -32,3 +32,9 @@
   padding: 0 1rem;
   width: 100%;
 }
+
+.signup-link {
+  text-decoration: underline;
+  text-align: center;
+  margin: 16px;
+}

--- a/src/app/signin/signin.component.ts
+++ b/src/app/signin/signin.component.ts
@@ -2,11 +2,11 @@ import { Component, inject } from '@angular/core';
 import { ApiService, isApiError } from '../service/api.service';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { UserService } from '../service/user.service';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-signin',
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, RouterLink],
   templateUrl: './signin.component.html',
   styleUrl: './signin.component.scss',
 })

--- a/src/app/signup/signup.component.html
+++ b/src/app/signup/signup.component.html
@@ -20,3 +20,7 @@
 @if (result) {
   <div>{{ result }}</div>
 }
+
+<div class="signin-link">
+  <a [routerLink]="'/signin'">すでにアカウントをお持ちの方</a>
+</div>

--- a/src/app/signup/signup.component.scss
+++ b/src/app/signup/signup.component.scss
@@ -32,3 +32,9 @@
   padding: 0 1rem;
   width: 100%;
 }
+
+.signin-link {
+  text-decoration: underline;
+  text-align: center;
+  margin: 16px;
+}

--- a/src/app/signup/signup.component.ts
+++ b/src/app/signup/signup.component.ts
@@ -2,11 +2,11 @@ import { Component, inject, OnInit } from '@angular/core';
 import { ApiService, isApiError } from '../service/api.service';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { UserService } from '../service/user.service';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-signup',
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, RouterLink],
   templateUrl: './signup.component.html',
   styleUrl: './signup.component.scss',
 })

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,3 +9,9 @@ body {
   // レイアウトがわかりやすいように仮にグレーに設定
   background-color: gray;
 }
+
+// aタグのスタイルをリセット
+a {
+  text-decoration: none;
+  color: inherit;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1880,6 +1880,20 @@
     "@napi-rs/nice-win32-ia32-msvc" "1.0.1"
     "@napi-rs/nice-win32-x64-msvc" "1.0.1"
 
+"@ng-icons/core@^29.10.0":
+  version "29.10.0"
+  resolved "https://registry.yarnpkg.com/@ng-icons/core/-/core-29.10.0.tgz#04f98a8ac2bba77d263cc1864e5a6ae0f00c5935"
+  integrity sha512-PR6SO00yvFhwDhh37BWhtAgRfzxuXpJQBsAQ44Pg3gjc83fOAwOtMSXizYwtN0uUFIkAYZHZCEuV7Sb8eosK+w==
+  dependencies:
+    tslib "^2.3.0"
+
+"@ng-icons/font-awesome@^29.10.0":
+  version "29.10.0"
+  resolved "https://registry.yarnpkg.com/@ng-icons/font-awesome/-/font-awesome-29.10.0.tgz#39663b05e397a11ba82a4c365c3a13a57d80000c"
+  integrity sha512-lxT4xuC3F9txO7AujR7UIgC9okt2ld+mlQRSdrFURht+c/7huOvFtqQVlE3UUlvEBdjyTBC4yE9SH4eH97sbVQ==
+  dependencies:
+    tslib "^2.3.0"
+
 "@ngtools/webpack@19.0.5":
   version "19.0.5"
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-19.0.5.tgz#4a18f718b269dfc443a07fcc86d780c5494e1e9f"


### PR DESCRIPTION
## 変更点

- 管理画面のリンクをヘッダーに移行（TopComponentからは削除）
  - 管理者のみ表示するように
- ログアウト方法をユーザー名ダブルタップに変更
- ヘッダーにあった新規登録・ログイン導線を削除
  - 新規登録⇔ログイン ページ間のリンクを追加

## 動作確認

- [x] 管理者のみヘッダーに管理画面等のリンクが表示されている
  - [x] アイコンが適切に表示されている
- [x] ログイン後、ユーザー名タップでログアウトできる（ダイアログが出るようになっています）
- [x] 新規登録画面でログイン画面へのリンクが追加されている
- [x] ログイン画面で新規登録画面へのリンクが追加されている