### PR TITLE
💄 管理画面で現在のステータスをわかるようにした

### DIFF
--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -1,4 +1,23 @@
 <div>
+  <div class="status-now-status">
+    <h3>現在のステータス</h3>
+    @switch (nowStatus()?.status) {
+      @case ("waiting") {
+        <div>待機中</div>
+      }
+      @case ("open") {
+        <div>question_id：{{ questionId }} を出題中</div>
+      }
+      @case ("close") {
+        <div>question_id：{{ questionId }} の回答を締め切り</div>
+      }
+      @case ("finish") {
+        <div>ゲーム終了</div>
+      }
+      @default {}
+    }
+  </div>
+
   <div>
     <button (click)="sendStatus('waiting')">待機</button>
   </div>

--- a/src/app/control/status/status.component.scss
+++ b/src/app/control/status/status.component.scss
@@ -1,5 +1,12 @@
+.status-now-status {
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+  gap: 8px;
+}
+
 .question-buttons {
-    display: flex;
-    padding: 8px 0;
-    gap: 8px;
+  display: flex;
+  padding: 8px 0;
+  gap: 8px;
 }

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -1,6 +1,7 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { ApiService, isApiError } from '../../service/api.service';
 import { FormsModule } from '@angular/forms';
+import { Status } from '../../service/api.interface';
 
 @Component({
   selector: 'app-status',
@@ -14,6 +15,8 @@ export class StatusComponent {
   result: string | undefined;
 
   questionId: string | undefined;
+
+  nowStatus = signal<Status | undefined>(undefined);
 
   sendStatus(status: string, questionId?: string) {
     switch (status) {
@@ -49,15 +52,25 @@ export class StatusComponent {
         switch (status) {
           case 'waiting':
             this.result = 'ステータスを「待機中」に設定しました';
+            this.nowStatus.set({ status: 'waiting' });
             break;
           case 'open':
             this.result = `問題${questionId}を出題しました`;
+            this.nowStatus.set({
+              status: 'open',
+              questionId: parseQuestionId!,
+            });
             break;
           case 'close':
             this.result = `問題${questionId}の回答を締め切りました`;
+            this.nowStatus.set({
+              status: 'close',
+              questionId: parseQuestionId!,
+            });
             break;
           case 'finish':
             this.result = 'ステータスを「終了」に設定しました';
+            this.nowStatus.set({ status: 'finish' });
             break;
         }
       });


### PR DESCRIPTION
## 変更点
- 管理画面で現在設定されているステータスを表示するようにした

## 動作確認
- [x] adminでログインする
- [x] ステータスを待機中に設定する。「現在のステータス」の右横に「待機中」と表示される
- [x] ステータスを出題に設定する。「現在のステータス」の右横に「question_id: xxを出題中」と表示される
- [x] ステータスを回答締め切りに設定する。「現在のステータス」の右横に「question_id: xxの回答を締め切り」と表示される
- [x] ステータスを終了に設定する。「現在のステータス」の右横に「ゲーム終了」と表示される