### PR TITLE
👍 回答画面の残り時間表示を追加と連打防止を追加

### DIFF
--- a/src/app/question/question.component.html
+++ b/src/app/question/question.component.html
@@ -18,7 +18,7 @@
         class="button"
         [class.select]="selectId() === choice.choiceId"
         (click)="sendAnswer(choice.choiceId)"
-        [disabled]="!isOpen()"
+        [disabled]="!isOpen() || sending()"
       >
         {{ choice.text }}
       </button>

--- a/src/app/question/question.component.html
+++ b/src/app/question/question.component.html
@@ -2,7 +2,13 @@
   <div class="question">
     <ng-icon class="icon-q" name="faSolidQ" />これだれ？
   </div>
-  <div class="next-question-timer">次の問題まで ◯</div>
+  <div class="next-question-timer">
+    @if (isOpen()) {
+      回答終了まで　<span class="remaining-time">{{ remainingTime() }}</span>
+    } @else {
+      回答を締め切りました
+    }
+  </div>
   <div class="image-container">
     <img class="image" [appAuthSrc]="question.imageUrl" [alt]="'問題画像'" />
   </div>

--- a/src/app/question/question.component.scss
+++ b/src/app/question/question.component.scss
@@ -27,6 +27,11 @@
   padding: 10px;
   background-color: #ddd;
   text-align: center;
+
+  .remaining-time {
+    color: var(--color-primary);
+    font-weight: bold;
+  }
 }
 
 .image-container {

--- a/src/app/question/question.component.ts
+++ b/src/app/question/question.component.ts
@@ -11,6 +11,7 @@ import { GetQuestionRes, Status } from '../service/api.interface';
 import { AuthImageDirective } from '../directive/auth-image.directive';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { faSolidQ } from '@ng-icons/font-awesome/solid';
+import { forkJoin, interval, Subscription, tap, timer } from 'rxjs';
 
 @Component({
   selector: 'app-question',
@@ -47,6 +48,10 @@ export class QuestionComponent {
 
   selectId = signal<number | undefined>(undefined);
 
+  INITIAL_REMAINING_TIME = 30;
+  remainingTime = signal(this.INITIAL_REMAINING_TIME);
+  remainingTimeTimer: Subscription | undefined = undefined;
+
   constructor() {
     effect(() => {
       const id = this.questionId();
@@ -58,6 +63,18 @@ export class QuestionComponent {
         }
         this.question.set(data);
       });
+    });
+
+    effect(() => {
+      const isOpen = this.isOpen();
+      if (!isOpen) {
+        this.remainingTimeTimer?.unsubscribe();
+      } else {
+        this.remainingTime.set(this.INITIAL_REMAINING_TIME);
+        this.remainingTimeTimer = interval(1000).subscribe(() => {
+          this.remainingTime.update((time) => Math.floor(time - 1));
+        });
+      }
     });
   }
 


### PR DESCRIPTION
##  変更点

- 残り時間を表示するようにした
  - いろいろ考えるの難しそうなので、一旦マイナスになっても止まらないという仕様に
- 連打防止で、最低2秒間は再送できないようにしました

## 動作確認

- [x] 出題中はカウントダウンされている
  - [x] マイナスになってもカウントダウンは続いている
- [x] 回答締め切られると表示も変わる
  - [x] 再度出題中にすると、また30秒からカウントダウンが始まる
- [x] 出題中に回答したとき、２秒間は再送できないようになっている