### PR TITLE
👍 フォーカス時のフォーカスリング色を設定

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -62,7 +62,7 @@ a {
     border: 2px solid var(--color-border);
     border-radius: 4px;
     height: 36px;
-    outline-color: var(--color-primary);
+    outline-offset: -2px;
     padding: 0 16px;
     width: 100%;
   }
@@ -76,4 +76,9 @@ a {
 
 * {
   box-sizing: border-box;
+
+  &:focus-visible {
+    outline: solid 2px var(--color-primary);
+    outline-offset: 2px;
+  }
 }


### PR DESCRIPTION
Close #50

## 変更点

- フォーカスリング の色を設定

## 動作確認

- [x] ボタンやインプットをフォーカス時（Tabなどで）に プライマリーカラーになっている

## 備考

アウトラインオフセットを2px にしている関係で、管理画面のインプット欄のフォーカスリングが見切れますが、プレイヤーのスタイリング重視で行きたいと思います。