### PR TITLE
🚑 問題が変わったときに選択肢の選択状態が解除されるように変更

### DIFF
--- a/src/app/question/question.component.ts
+++ b/src/app/question/question.component.ts
@@ -57,6 +57,7 @@ export class QuestionComponent {
           return;
         }
         this.question.set(data);
+        this.selectId.set(undefined);
       });
     });
   }


### PR DESCRIPTION
Close #51 

## 変更点

- 問題が変わったときに選択状態が解除されるように変更

## 動作確認

- [x] 回答を選択した状態で、別の問題に移ると選択が解除される
- [x] 回答を締め切っても選択状態は解除されない

