### PR TITLE
🚑 QRコードから新規登録できないバグを修正

### DIFF
--- a/src/app/signup/signup.component.ts
+++ b/src/app/signup/signup.component.ts
@@ -42,9 +42,9 @@ export class SignupComponent implements OnInit {
   submit() {
     this.sending.set(true);
     const data = {
-      username: this.formData.value.username ?? '',
-      password: this.formData.value.password ?? '',
-      inviteCode: this.formData.value.inviteCode ?? '',
+      username: this.formData.getRawValue().username ?? '',
+      password: this.formData.getRawValue().password ?? '',
+      inviteCode: this.formData.getRawValue().inviteCode ?? '',
     };
 
     this.api.signUp(data).subscribe((res) => {


### PR DESCRIPTION
## 変更点

- フォームからの値取得を `getRawValue` を使うように変更

## 動作確認

- [x] 下記のQRから新規登録ができる
![image](https://github.com/user-attachments/assets/294437e5-4d60-4b4a-a134-2f6a2c5f093d)

## 原因

disabled なフォームからは普通の `value` で値が取ってこれないみたいでした
