### PR TITLE
👍 スマホでの先頭大文字入力モードをオフに設定 & ボタン下の余白を追加

### DIFF
--- a/src/app/signin/signin.component.html
+++ b/src/app/signin/signin.component.html
@@ -2,7 +2,12 @@
   <form class="form" [formGroup]="formData" (ngSubmit)="submit()">
     <div class="input-container">
       <label for="username" class="label">ユーザー名</label>
-      <input id="username" class="input" [formControlName]="'username'" />
+      <input
+        id="username"
+        class="input"
+        autocapitalize="off"
+        [formControlName]="'username'"
+      />
     </div>
 
     <div class="input-container">

--- a/src/app/signin/signin.component.scss
+++ b/src/app/signin/signin.component.scss
@@ -30,4 +30,5 @@
   text-decoration: underline;
   text-align: center;
   margin: 16px;
+  margin-top: 36px;
 }

--- a/src/app/signup/signup.component.html
+++ b/src/app/signup/signup.component.html
@@ -2,7 +2,12 @@
   <form class="form" [formGroup]="formData" (ngSubmit)="submit()">
     <div class="input-container">
       <label for="username" class="label">ユーザー名</label>
-      <input id="username" class="input" [formControlName]="'username'" />
+      <input
+        id="username"
+        class="input"
+        autocapitalize="off"
+        [formControlName]="'username'"
+      />
       <div class="helper-text">
         {{
           "※ Slack の表示名 または、メールアドレスの @ 以前 でお願いいたします"

--- a/src/app/signup/signup.component.scss
+++ b/src/app/signup/signup.component.scss
@@ -30,4 +30,5 @@
   text-decoration: underline;
   text-align: center;
   margin: 16px;
+  margin-top: 36px;
 }


### PR DESCRIPTION
Close #62 

## 変更点

- スマホでユーザー名inputを選択したときに、先頭大文字モードになっていたのを修正
- ボタンと下のリンクとの余白を広くした

## 動作確認

- [x] スマホで見たときに、ユーザー名を入力する際、デフォルトで大文字で入力が始まらない