### PR TITLE
👍 管理画面に全ての回答状況をリセットするボタンを設置

### DIFF
--- a/src/app/control/control.component.html
+++ b/src/app/control/control.component.html
@@ -11,6 +11,8 @@
     <app-status></app-status>
   </div>
 
+  <hr />
+
   <div>
     <h2>リセット</h2>
     <app-delete></app-delete>

--- a/src/app/control/control.component.html
+++ b/src/app/control/control.component.html
@@ -10,4 +10,9 @@
     <h2>ステータス管理</h2>
     <app-status></app-status>
   </div>
+
+  <div>
+    <h2>リセット</h2>
+    <app-delete></app-delete>
+  </div>
 </div>

--- a/src/app/control/control.component.ts
+++ b/src/app/control/control.component.ts
@@ -2,10 +2,11 @@ import { Component } from '@angular/core';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { RegisterComponent } from './register/register.component';
 import { StatusComponent } from './status/status.component';
+import { DeleteComponent } from './delete/delete.component';
 
 @Component({
   selector: 'app-control',
-  imports: [RegisterComponent, StatusComponent],
+  imports: [RegisterComponent, StatusComponent, DeleteComponent],
   templateUrl: './control.component.html',
   styleUrl: './control.component.scss',
 })

--- a/src/app/control/delete/delete.component.html
+++ b/src/app/control/delete/delete.component.html
@@ -1,0 +1,1 @@
+<p>delete works!</p>

--- a/src/app/control/delete/delete.component.html
+++ b/src/app/control/delete/delete.component.html
@@ -1,1 +1,1 @@
-<p>delete works!</p>
+<button class="delete-button">⚠️ すべての回答状況をリセット</button>

--- a/src/app/control/delete/delete.component.html
+++ b/src/app/control/delete/delete.component.html
@@ -1,1 +1,6 @@
-<button class="delete-button">⚠️ すべての回答状況をリセット</button>
+<button class="delete-button" (click)="deleteAnswers()">
+  ⚠️ すべての回答状況をリセット
+</button>
+@if (result) {
+  <div>{{ result }}</div>
+}

--- a/src/app/control/delete/delete.component.scss
+++ b/src/app/control/delete/delete.component.scss
@@ -1,0 +1,12 @@
+.delete-button {
+  background-color: #f44336;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  padding: 10px 20px;
+  text-align: center;
+  display: inline-block;
+  font-size: 16px;
+  margin: 4px 2px;
+  cursor: pointer;
+}

--- a/src/app/control/delete/delete.component.ts
+++ b/src/app/control/delete/delete.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-delete',
+  imports: [],
+  templateUrl: './delete.component.html',
+  styleUrl: './delete.component.scss'
+})
+export class DeleteComponent {
+
+}

--- a/src/app/control/delete/delete.component.ts
+++ b/src/app/control/delete/delete.component.ts
@@ -4,8 +4,6 @@ import { Component } from '@angular/core';
   selector: 'app-delete',
   imports: [],
   templateUrl: './delete.component.html',
-  styleUrl: './delete.component.scss'
+  styleUrl: './delete.component.scss',
 })
-export class DeleteComponent {
-
-}
+export class DeleteComponent {}

--- a/src/app/control/delete/delete.component.ts
+++ b/src/app/control/delete/delete.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ApiService, isApiError } from '../../service/api.service';
 
 @Component({
   selector: 'app-delete',
@@ -6,4 +7,22 @@ import { Component } from '@angular/core';
   templateUrl: './delete.component.html',
   styleUrl: './delete.component.scss',
 })
-export class DeleteComponent {}
+export class DeleteComponent {
+  api = inject(ApiService);
+
+  result: string | undefined;
+
+  deleteAnswers() {
+    if (!window.confirm('全ての回答状況をリセットしますか？')) return;
+    if (!window.confirm('この操作は取り消せません。本当によろしいですか？'))
+      return;
+
+    this.api.deleteAnswer().subscribe((data) => {
+      if (isApiError(data)) {
+        this.result = `${data.error.message} (${data.error.code})`;
+        return;
+      }
+      this.result = 'すべての回答状況をリセットしました';
+    });
+  }
+}

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -94,6 +94,11 @@ export class ApiService {
     return this.get<GetQuestionForProjectorRes>('/questions/admin/' + id);
   }
 
+  /** すべての回答状況をリセット */
+  deleteAnswer() {
+    return this.delete('/answers');
+  }
+
   /** 認証付きGETリクエスト */
   private get<T = {}>(path: string) {
     return this.httpClient.get<T | ApiError>(this.baseUrl + path, {
@@ -104,6 +109,13 @@ export class ApiService {
   /** 認証付きPOSTリクエスト */
   private post<T = {}>(path: string, body: any | null) {
     return this.httpClient.post<T | ApiError>(this.baseUrl + path, body, {
+      headers: { Authorization: `Bearer ${this.getToken()}` },
+    });
+  }
+
+  /** 認証付きDELETEリクエスト */
+  private delete<T = {}>(path: string) {
+    return this.httpClient.delete<T | ApiError>(this.baseUrl + path, {
       headers: { Authorization: `Bearer ${this.getToken()}` },
     });
   }


### PR DESCRIPTION
## 変更点
- 回答状況をリセットするAPIサービスを追加
- 管理画面に回答状況をリセットするボタンを設置

## 動作確認
- [x] adminでログインする
- [x] 管理画面でリセットボタンをクリックする
- [x] 確認のダイアログが2回表示された後、`DELETE /answers`のAPIリクエストが発生する
- [x] 回答がリセットされていることが確認できる

