### PR TITLE
👍 管理画面にすべてのユーザー登録をリセットするボタンを設置

### DIFF
--- a/src/app/control/control.component.html
+++ b/src/app/control/control.component.html
@@ -15,6 +15,9 @@
 
   <div>
     <h2>リセット</h2>
-    <app-delete></app-delete>
+    <div class="control-reset-button-container">
+      <app-delete></app-delete>
+      <app-delete-user></app-delete-user>
+    </div>
   </div>
 </div>

--- a/src/app/control/control.component.scss
+++ b/src/app/control/control.component.scss
@@ -1,0 +1,5 @@
+.control-reset-button-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/app/control/control.component.ts
+++ b/src/app/control/control.component.ts
@@ -3,10 +3,16 @@ import { RouterLink, RouterOutlet } from '@angular/router';
 import { RegisterComponent } from './register/register.component';
 import { StatusComponent } from './status/status.component';
 import { DeleteComponent } from './delete/delete.component';
+import { DeleteUserComponent } from './delete-user/delete-user.component';
 
 @Component({
   selector: 'app-control',
-  imports: [RegisterComponent, StatusComponent, DeleteComponent],
+  imports: [
+    RegisterComponent,
+    StatusComponent,
+    DeleteComponent,
+    DeleteUserComponent,
+  ],
   templateUrl: './control.component.html',
   styleUrl: './control.component.scss',
 })

--- a/src/app/control/delete-user/delete-user.component.html
+++ b/src/app/control/delete-user/delete-user.component.html
@@ -1,0 +1,1 @@
+<p>delete-user works!</p>

--- a/src/app/control/delete-user/delete-user.component.html
+++ b/src/app/control/delete-user/delete-user.component.html
@@ -1,1 +1,6 @@
-<p>delete-user works!</p>
+<button class="delete-user-button" (click)="deleteUser()">
+  ⚠️ すべてのユーザー登録をリセット
+</button>
+@if (result) {
+  <div>{{ result }}</div>
+}

--- a/src/app/control/delete-user/delete-user.component.scss
+++ b/src/app/control/delete-user/delete-user.component.scss
@@ -1,0 +1,12 @@
+.delete-user-button {
+  background-color: #f44336;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  padding: 10px 20px;
+  text-align: center;
+  display: inline-block;
+  font-size: 16px;
+  margin: 4px 2px;
+  cursor: pointer;
+}

--- a/src/app/control/delete-user/delete-user.component.ts
+++ b/src/app/control/delete-user/delete-user.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-delete-user',
+  imports: [],
+  templateUrl: './delete-user.component.html',
+  styleUrl: './delete-user.component.scss'
+})
+export class DeleteUserComponent {
+
+}

--- a/src/app/control/delete-user/delete-user.component.ts
+++ b/src/app/control/delete-user/delete-user.component.ts
@@ -1,11 +1,28 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { ApiService, isApiError } from '../../service/api.service';
 
 @Component({
   selector: 'app-delete-user',
   imports: [],
   templateUrl: './delete-user.component.html',
-  styleUrl: './delete-user.component.scss'
+  styleUrl: './delete-user.component.scss',
 })
 export class DeleteUserComponent {
+  api = inject(ApiService);
 
+  result: string | undefined;
+
+  deleteUser() {
+    if (!window.confirm('全てのユーザー登録をリセットしますか？')) return;
+    if (!window.confirm('この操作は取り消せません。本当によろしいですか？'))
+      return;
+
+    this.api.deleteUser().subscribe((data) => {
+      if (isApiError(data)) {
+        this.result = `${data.error.message} (${data.error.code})`;
+        return;
+      }
+      this.result = 'すべてのユーザー登録をリセットしました';
+    });
+  }
 }

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -100,6 +100,11 @@ export class ApiService {
     return this.delete('/answers');
   }
 
+  /** すべてのユーザー登録をリセット */
+  deleteUser() {
+    return this.delete('/deleteUser');
+  }
+
   /** 各選択肢の回答数の取得（プロジェクター用） */
   getAnswers(questionId: number) {
     return this.get<GetAnswersRes>('/questions/' + questionId + '/answers');


### PR DESCRIPTION
## 変更点
- すべての登録済みユーザーをリセットするAPIサービスを追加
- 管理画面に登録済みユーザーをリセットするボタンを設置

## 動作確認
- [x] adminでログインする
- [x] 「すべてのユーザー登録をリセット」をクリック
- [x] 確認ダイアログが2回出た後、すべての登録済みユーザーがリセットされていることが確認できる