### PR TITLE
👍 管理画面からプロジェクターの回答表示をできるように

### DIFF
--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -29,6 +29,7 @@
   <div class="question-buttons">
     <button (click)="sendStatus('open', questionId)">問題出題</button>
     <button (click)="sendStatus('close', questionId)">回答締め切り</button>
+    <button (click)="showAnswers()">回答表示</button>
   </div>
 
   <div>

--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -29,7 +29,12 @@
   <div class="question-buttons">
     <button (click)="sendStatus('open', questionId)">問題出題</button>
     <button (click)="sendStatus('close', questionId)">回答締め切り</button>
-    <button (click)="showAnswers()">回答表示</button>
+    <button
+      (click)="showAnswers()"
+      [disabled]="!this.projectorService.serviceEnable()"
+    >
+      回答表示
+    </button>
   </div>
 
   <div>

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, signal } from '@angular/core';
 import { ApiService, isApiError } from '../../service/api.service';
 import { FormsModule } from '@angular/forms';
 import { Status } from '../../service/api.interface';
+import { ProjectorService } from '../../service/projector.service';
 
 @Component({
   selector: 'app-status',
@@ -11,6 +12,7 @@ import { Status } from '../../service/api.interface';
 })
 export class StatusComponent {
   api = inject(ApiService);
+  projectorService = inject(ProjectorService);
 
   result: string | undefined;
 
@@ -74,5 +76,9 @@ export class StatusComponent {
             break;
         }
       });
+  }
+
+  showAnswers() {
+    this.projectorService.postMessage('showAnswers');
   }
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -6,10 +6,10 @@
         <span>管理画面</span>
       </a>
 
-      <a class="link" [routerLink]="'/projector'">
+      <button class="link" (click)="openProjectorPage()">
         <ng-icon name="faSolidDisplay" />
         <span>プロジェクター用</span>
-      </a>
+      </button>
     </div>
   }
   <div class="spacer"></div>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -14,6 +14,13 @@ header {
     gap: 4px;
   }
 
+  button.link {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+  }
+
   ng-icon {
     height: 24px;
     width: 24px;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -7,6 +7,7 @@ import {
   faSolidDisplay,
   faSolidScrewdriverWrench,
 } from '@ng-icons/font-awesome/solid';
+import { ProjectorService } from '../service/projector.service';
 
 @Component({
   selector: 'app-header',
@@ -19,6 +20,7 @@ export class HeaderComponent {
   router = inject(Router);
   apiService = inject(ApiService);
   userService = inject(UserService);
+  projectorService = inject(ProjectorService);
 
   isAdmin = computed(() => {
     return this.userService.user()?.role === 'ADMIN';
@@ -29,5 +31,10 @@ export class HeaderComponent {
       this.userService.signout();
       window.location.href = '/';
     }
+  }
+
+  openProjectorPage() {
+    const targetWindow = window.open('/projector', '_blank');
+    this.projectorService.setWindow(targetWindow);
   }
 }

--- a/src/app/projector/projector.component.ts
+++ b/src/app/projector/projector.component.ts
@@ -31,6 +31,7 @@ export class ProjectorComponent {
     this.pollingSubscription = interval(3000).subscribe(() => {
       this.updateStatus();
     });
+    this.updateStatus();
   }
 
   ngOnDestroy() {

--- a/src/app/projector/screen-question/screen-question.component.html
+++ b/src/app/projector/screen-question/screen-question.component.html
@@ -36,17 +36,6 @@
     </div>
   </div>
 
-  @if (nowStatus().status === "close") {
-    <div class="screen-question-show-answer-button-container">
-      <button
-        class="screen-question-show-answer-button"
-        (click)="showAnswers()"
-      >
-        回答を表示
-      </button>
-    </div>
-  }
-
   @if (result) {
     <div>{{ result }}</div>
   }

--- a/src/app/projector/screen-question/screen-question.component.scss
+++ b/src/app/projector/screen-question/screen-question.component.scss
@@ -74,21 +74,3 @@
   justify-content: space-between;
   margin: 0px 64px;
 }
-
-.screen-question-show-answer-button-container {
-  position: absolute;
-  padding: 8px 16px;
-  bottom: 10%;
-}
-
-.screen-question-show-answer-button {
-  margin: 0px 16px;
-  padding: 8px 16px;
-  border: solid 2px var(--color-primary);
-  border-radius: 8px;
-  font-size: 16px;
-  font-weight: 600;
-  letter-spacing: 2px;
-  color: black;
-  background-color: white;
-}

--- a/src/app/projector/screen-question/screen-question.component.ts
+++ b/src/app/projector/screen-question/screen-question.component.ts
@@ -121,6 +121,7 @@ export class ScreenQuestionComponent implements OnDestroy {
   }
 
   showAnswers() {
+    if (this.nowStatus().status !== 'close') return;
     this.isShowAnswer.set(true);
   }
 }

--- a/src/app/projector/screen-question/screen-question.component.ts
+++ b/src/app/projector/screen-question/screen-question.component.ts
@@ -4,6 +4,7 @@ import {
   effect,
   inject,
   input,
+  OnDestroy,
   signal,
 } from '@angular/core';
 import { ApiService, isApiError } from '../../service/api.service';
@@ -13,6 +14,8 @@ import {
   Status,
 } from '../../service/api.interface';
 import { AuthImageDirective } from '../../directive/auth-image.directive';
+import { ProjectorService } from '../../service/projector.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-screen-question',
@@ -20,8 +23,11 @@ import { AuthImageDirective } from '../../directive/auth-image.directive';
   templateUrl: './screen-question.component.html',
   styleUrl: './screen-question.component.scss',
 })
-export class ScreenQuestionComponent {
+export class ScreenQuestionComponent implements OnDestroy {
   api = inject(ApiService);
+  projectorService = inject(ProjectorService);
+
+  subscription = new Subscription();
 
   nowStatus = input.required<Status>();
 
@@ -70,6 +76,18 @@ export class ScreenQuestionComponent {
         }
       }
     });
+
+    this.subscription.add(
+      this.projectorService.messageEvent().subscribe((message) => {
+        if (message === 'showAnswers') {
+          this.showAnswers();
+        }
+      }),
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
   }
 
   getAnswers(questionId: number) {

--- a/src/app/projector/screen-question/screen-question.component.ts
+++ b/src/app/projector/screen-question/screen-question.component.ts
@@ -15,7 +15,7 @@ import {
 } from '../../service/api.interface';
 import { AuthImageDirective } from '../../directive/auth-image.directive';
 import { ProjectorService } from '../../service/projector.service';
-import { Subscription } from 'rxjs';
+import { fromEvent, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-screen-question',
@@ -80,6 +80,16 @@ export class ScreenQuestionComponent implements OnDestroy {
     this.subscription.add(
       this.projectorService.messageEvent().subscribe((message) => {
         if (message === 'showAnswers') {
+          this.showAnswers();
+        }
+      }),
+    );
+
+    this.subscription.add(
+      fromEvent<KeyboardEvent>(window, 'keydown').subscribe((event) => {
+        console.log(event);
+        if (event.key === 's') {
+          // show の s
           this.showAnswers();
         }
       }),

--- a/src/app/service/projector.service.ts
+++ b/src/app/service/projector.service.ts
@@ -7,6 +7,10 @@ import { fromEvent, mergeMap } from 'rxjs';
 export class ProjectorService {
   private targetWindow: Window | null = null;
 
+  serviceEnable() {
+    return this.targetWindow !== null;
+  }
+
   setWindow(window: Window | null) {
     this.targetWindow = window;
   }

--- a/src/app/service/projector.service.ts
+++ b/src/app/service/projector.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { fromEvent, mergeMap } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProjectorService {
+  private targetWindow: Window | null = null;
+
+  setWindow(window: Window | null) {
+    this.targetWindow = window;
+  }
+
+  postMessage(message: string) {
+    if (this.targetWindow === null) return;
+    this.targetWindow.postMessage(message, window.location.origin);
+  }
+
+  messageEvent() {
+    return fromEvent<MessageEvent>(window, 'message').pipe(
+      mergeMap((event) => {
+        if (event.origin !== window.location.origin) return [];
+        if (typeof event.data !== 'string') return [];
+        return [event.data];
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## 変更点

- ヘッダーの「プロジェクター用」というボタンで新規タブを開くように変更
- 管理画面に「回答表示」ボタンを追加
- プロジェクター画面の「回答表示」ボタンを削除
  - 念のため、プロジェクター画面がアクティブの時、「s」（show の s）を押すと回答が表示されるように
- プロジェクター画面初期描画時にステータスを取得していなかったので修正

## 動作確認
ADMINで確認してください

- [x] ヘッダーの「プロジェクター用」というボタンで新規タブが開く
- [x] 管理画面で回答を締め切り、「回答表示」ボタンを押すと、上記で開いた画面で回答が表示される（途中で管理画面をリロードしちゃうとうまく動きません）
- [x] 管理画面で回答を締め切り、プロジェクター画面上で「s」キーを押すと、回答が表示される（管理画面の回答表示ボタンがうまく動かないときはこれで対処）