### PR TITLE
🐛 img タグのURLが変わった際に、一度画像をリセットするように変更

### DIFF
--- a/src/app/directive/auth-image.directive.ts
+++ b/src/app/directive/auth-image.directive.ts
@@ -22,6 +22,10 @@ export class AuthImageDirective {
       if (!url.includes(ENV.API_BASE)) {
         this.el.nativeElement.src = url;
         return;
+      } else {
+        // 読み込みまでの間は白単色のダミー画像を表示（でないと blokenicon が出てしまう）
+        this.el.nativeElement.src =
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQYV2P4////fwAJ+wP9BUNFygAAAABJRU5ErkJggg==';
       }
       this.apiService.getImage(url).subscribe((res) => {
         this.el.nativeElement.src = URL.createObjectURL(res);


### PR DESCRIPTION
## 変更点

- appAuthSrc が変わったときに 白単色のダミー画像を設定し、画像の読み込みが終わったらその画像を表示するように変更

## 動作確認

- [x] 問題を切り替えたとき、選択肢が変わったタイミングで画像がいったん消え、読み込み終了したら表示される

## 備考
https://zenn.dev/anozon/articles/1px-data-url
↑ を参考に DataURLを設定
