### PR TITLE
👍 ログイン時には新規登録・ログインページに飛べないように変更

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -35,6 +35,19 @@ const loginGuard: CanActivateFn = () => {
   );
 };
 
+const unloginGuard: CanActivateFn = () => {
+  const userService = inject(UserService);
+  const router = inject(Router);
+  return userService.getUser().pipe(
+    mergeMap((data) => {
+      if (data) return of(router.parseUrl('/'));
+      else {
+        return of(true);
+      }
+    }),
+  );
+};
+
 export const routes: Routes = [
   {
     path: '',
@@ -74,12 +87,18 @@ export const routes: Routes = [
     ],
   },
   {
-    path: 'signup',
-    component: SignupComponent,
-  },
-  {
-    path: 'signin',
-    component: SigninComponent,
+    path: '',
+    canActivate: [unloginGuard],
+    children: [
+      {
+        path: 'signup',
+        component: SignupComponent,
+      },
+      {
+        path: 'signin',
+        component: SigninComponent,
+      },
+    ],
   },
   { path: '**', redirectTo: '/' },
 ];

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -27,7 +27,7 @@ export class HeaderComponent {
   });
 
   signout() {
-    if (window.confirm('サインアウトしますか？')) {
+    if (window.confirm('ログアウトしますか？')) {
       this.userService.signout();
       window.location.href = '/';
     }


### PR DESCRIPTION
Close #86 

## 変更点


- ログインした状態で `/signup` や `/signin` に遷移しようとしても、トップに飛ぶように変更
- ログアウトするときの文言を「ログアウトしますか」に変更

## 動作確認

- [x] ログインした状態で `/signup` や `/signin` に遷移しようとしても、トップに飛ばされる
- [x] ログアウトするときの文言が「ログアウトしますか」なっている