### PR TITLE
👍💄 プロジェクター問題画面で元画像の表示とUIの調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ Thumbs.db
 
 .env
 src/environments/environment.json
+
+/public/*.png

--- a/src/app/projector/screen-question/screen-question.component.html
+++ b/src/app/projector/screen-question/screen-question.component.html
@@ -26,15 +26,21 @@
           ></div>
 
           <div class="screen-question-text-container">
-            <p>{{ choice.text }}</p>
+            <div>{{ choice.text }}</div>
             @if (nowStatus().status === "close") {
-              <p>{{ getCount(choice.choiceId) }}</p>
+              <div>{{ getCount(choice.choiceId) }}</div>
             }
           </div>
         </div>
       }
     </div>
   </div>
+
+  @if (nowStatus().status === "close" && isShowAnswer() && isShowImage()) {
+    <div class="screen-question-image-popup-container">
+      <div [style.background-image]="'url(/' + questionId() + 'o.png)'"></div>
+    </div>
+  }
 
   @if (result) {
     <div>{{ result }}</div>

--- a/src/app/projector/screen-question/screen-question.component.scss
+++ b/src/app/projector/screen-question/screen-question.component.scss
@@ -1,10 +1,12 @@
 .screen-question-body {
+  position: relative;
   height: 100%;
   margin: 0px 16px;
   display: flex;
   align-items: center;
   justify-content: left;
   gap: 32px;
+  padding: 32px;
 }
 
 .screen-question-image-container {
@@ -16,8 +18,7 @@
 }
 
 .screen-question-image {
-  width: 80%;
-  max-height: 100%;
+  height: 100%;
   border-radius: 8px;
   object-fit: contain;
 }
@@ -30,18 +31,24 @@
 }
 
 .screen-question-choice-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   width: 100%;
+  height: 100%;
+  justify-content: space-between;
 }
 
 .screen-question-choice {
+  width: 100%;
+  height: 30%;
   position: relative;
-  padding: 12px 16px;
-  margin: 8px 0px;
-  border: solid 2px var(--color-primary);
+  padding: 0px 16px;
+  border: solid 8px var(--color-primary);
   border-radius: 8px;
-  font-size: 64px;
+  font-size: 72px;
   font-weight: 600;
-  letter-spacing: 2px;
+  letter-spacing: 4px;
   color: black;
   background-color: white;
 
@@ -55,6 +62,9 @@
     background-color: var(--color-disabled);
     border-color: var(--color-disabled);
     color: white;
+    .screen-question-choice-overlay {
+      border-radius: 8px;
+    }
   }
 
   .screen-question-choice-overlay {
@@ -62,15 +72,44 @@
     width: 0%;
     background-color: black;
     opacity: 30%;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
+    inset: 0px;
+    border-radius: 0px;
+    transition: all 1s;
   }
 }
 
 .screen-question-text-container {
+  width: 100%;
+  height: 100%;
+  position: absolute;
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  margin: 0px 64px;
+  padding: 0px 64px;
+}
+
+.screen-question-image-popup-container {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50%;
+  height: 100%;
+  top: 0;
+  right: 16px;
+  bottom: 0;
+  margin: auto;
+  background-color: transparent;
+
+  div {
+    max-width: 100%;
+    max-height: 100%;
+    width: 80%;
+    height: 80%;
+    border: 8px solid var(--color-primary);
+    border-radius: 8px;
+    object-fit: contain;
+    background-size: cover;
+    background-position: center;
+  }
 }

--- a/src/app/projector/screen-question/screen-question.component.ts
+++ b/src/app/projector/screen-question/screen-question.component.ts
@@ -52,6 +52,7 @@ export class ScreenQuestionComponent implements OnDestroy {
 
   result: string | undefined;
   isShowAnswer = signal<boolean>(false);
+  isShowImage = signal<boolean>(false);
 
   constructor() {
     effect(() => {
@@ -59,6 +60,7 @@ export class ScreenQuestionComponent implements OnDestroy {
       if (id === undefined) return;
       this.answers.set(undefined);
       this.isShowAnswer.set(false);
+      this.isShowImage.set(false);
       this.api.getQuestionForProjector(id).subscribe((data) => {
         if (isApiError(data)) {
           this.result = `${data.error.message} (${data.error.code})`;
@@ -91,6 +93,9 @@ export class ScreenQuestionComponent implements OnDestroy {
         if (event.key === 's') {
           // show の s
           this.showAnswers();
+        } else if (event.key === 'i') {
+          // image の i
+          this.showImage();
         }
       }),
     );
@@ -123,5 +128,9 @@ export class ScreenQuestionComponent implements OnDestroy {
   showAnswers() {
     if (this.nowStatus().status !== 'close') return;
     this.isShowAnswer.set(true);
+  }
+
+  showImage() {
+    this.isShowImage.set(true);
   }
 }

--- a/src/app/projector/screen-question/screen-question.component.ts
+++ b/src/app/projector/screen-question/screen-question.component.ts
@@ -131,6 +131,7 @@ export class ScreenQuestionComponent implements OnDestroy {
   }
 
   showImage() {
+    if (this.nowStatus().status !== 'close') return;
     this.isShowImage.set(true);
   }
 }


### PR DESCRIPTION
## 変更点
- プロジェクターの問題画面で元画像を表示できるようにした
- UIの調整
- .gitignoreの更新（元画像追加のため）

## 動作確認
- [x] adminでログインする
- [x] プロジェクター画面を別ウインドウで開く
- [x] 管理画面から問題を出題、回答を締め切る
- [x] プロジェクター画面にフォーカスして s キーを押す
- [x] 正解の選択肢が強調表示される
- [x] i キーを押す
- [x] 生成画像に応じた元画像が画面の右半分に表示される