### PR TITLE
👍 管理画面にステータスを「ゲーム開始前」に設定するボタンを設置

### DIFF
--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -19,6 +19,10 @@
   </div>
 
   <div>
+    <button (click)="sendStatus('before')">ゲーム開始前</button>
+  </div>
+
+  <div>
     <button (click)="sendStatus('waiting')">待機</button>
   </div>
 

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -22,6 +22,8 @@ export class StatusComponent {
 
   sendStatus(status: string, questionId?: string) {
     switch (status) {
+      case 'before':
+        break;
       case 'waiting':
         break;
       case 'open':
@@ -52,6 +54,10 @@ export class StatusComponent {
         }
 
         switch (status) {
+          case 'before':
+            this.result = 'ステータスを「ゲーム開始前」に設定しました';
+            this.nowStatus.set({ status: 'before' });
+            break;
           case 'waiting':
             this.result = 'ステータスを「待機中」に設定しました';
             this.nowStatus.set({ status: 'waiting' });

--- a/src/app/service/api.interface.ts
+++ b/src/app/service/api.interface.ts
@@ -67,7 +67,7 @@ export type GetAnswersRes = {
 };
 
 export type Status =
-  | { status: 'waiting' | 'finish' }
+  | { status: 'waiting' | 'finish' | 'before' }
   | { status: 'open' | 'close'; questionId: number };
 
 export type ApiError = {


### PR DESCRIPTION
## 変更点
- Statusインターフェースにゲーム開始前を表す`before`を追加
- 管理画面にステータスを`before`に設定するボタンを設置

## 動作確認

- [x] adminでログインする
- [x] 管理画面の「ゲーム開始前」をクリックする。devツールから`before`ステータスが送信できていることが確認できる