### PR TITLE
👍 回答画面を開いたときに前回の回答を復元するように変更

### DIFF
--- a/src/app/service/api.interface.ts
+++ b/src/app/service/api.interface.ts
@@ -33,6 +33,11 @@ export type PostQuestionAnswerReq = {
   choiceId: number;
 };
 
+export type GetQuestionAnswerRes = {
+  // サーバー側がtypoしてる
+  choiseId: number;
+};
+
 export type Choice = {
   choiceId: number;
   text: string;

--- a/src/app/service/api.service.ts
+++ b/src/app/service/api.service.ts
@@ -6,6 +6,7 @@ import {
   ApiError,
   GetAnswersRes,
   GetMeRes,
+  GetQuestionAnswerRes,
   GetQuestionForProjectorRes,
   GetQuestionRes,
   PostQuestionAnswerReq,
@@ -63,9 +64,16 @@ export class ApiService {
     return this.get<GetQuestionRes>('/questions/' + id);
   }
 
-  /** 問題送信 */
+  /** 回答送信 */
   postAnswer(questionId: number, data: PostQuestionAnswerReq) {
     return this.post('/questions/' + questionId + '/answer', data);
+  }
+
+  /** 回答取得 */
+  getAnswer(questionId: number) {
+    return this.get<GetQuestionAnswerRes>(
+      '/questions/' + questionId + '/answer',
+    );
   }
 
   /** ステータス送信 */


### PR DESCRIPTION
Close #84 

## 変更点

- 問題が変わったとき（初期描画時も含む）に `GET /question/:id/answer` を叩いて前回の回答を復元するように変更

## 動作確認

- [x] 回答した状態でリロードしても選択状態が復元している
- [x] まだ回答していない状態でリロードしても未選択のまま