### PR TITLE
👍 ポーリング間隔を変更

### DIFF
--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -30,7 +30,7 @@ export class PlayerComponent {
   ngOnInit() {
     this.updateStatus();
     // ポーリングでステータスを取得
-    this.pollingSubscription = interval(3000).subscribe(() => {
+    this.pollingSubscription = interval(1000).subscribe(() => {
       this.updateStatus();
     });
   }

--- a/src/app/projector/projector.component.ts
+++ b/src/app/projector/projector.component.ts
@@ -28,7 +28,7 @@ export class ProjectorComponent {
 
   ngOnInit() {
     // ポーリングでステータスを取得
-    this.pollingSubscription = interval(3000).subscribe(() => {
+    this.pollingSubscription = interval(500).subscribe(() => {
       this.updateStatus();
     });
     this.updateStatus();


### PR DESCRIPTION
Close #94 

## 変更点

- 回答画面のポーリング間隔を3秒から1秒に変更しました
- プロジェクター画面のポーリング間隔を3秒から0.5秒に変更しました
  - status の変更にすぐついてきてほしいため 0.5秒にしています

## 動作確認

- [x] 回答画面で `/status` が1秒間隔で叩かれている
- [x] プロジェクターの画面で `/status` が0.5秒間隔で叩かれている

