### PR TITLE
🚑💄 管理画面の不具合修正と回答表示ボタンの削除

### DIFF
--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -33,12 +33,6 @@
   <div class="question-buttons">
     <button (click)="sendStatus('open', questionId)">問題出題</button>
     <button (click)="sendStatus('close', questionId)">回答締め切り</button>
-    <button
-      (click)="showAnswers()"
-      [disabled]="!this.projectorService.serviceEnable()"
-    >
-      回答表示
-    </button>
   </div>
 
   <div>

--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -2,6 +2,9 @@
   <div class="status-now-status">
     <h3>現在のステータス</h3>
     @switch (nowStatus()?.status) {
+      @case ("before") {
+        <div>ゲーム開始前</div>
+      }
       @case ("waiting") {
         <div>待機中</div>
       }

--- a/src/app/control/status/status.component.html
+++ b/src/app/control/status/status.component.html
@@ -6,10 +6,10 @@
         <div>待機中</div>
       }
       @case ("open") {
-        <div>question_id：{{ questionId }} を出題中</div>
+        <div>question_id：{{ nowQuestionId() }} を出題中</div>
       }
       @case ("close") {
-        <div>question_id：{{ questionId }} の回答を締め切り</div>
+        <div>question_id：{{ nowQuestionId() }} の回答を締め切り</div>
       }
       @case ("finish") {
         <div>ゲーム終了</div>

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -2,7 +2,6 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { ApiService, isApiError } from '../../service/api.service';
 import { FormsModule } from '@angular/forms';
 import { Status } from '../../service/api.interface';
-import { ProjectorService } from '../../service/projector.service';
 
 @Component({
   selector: 'app-status',
@@ -12,7 +11,6 @@ import { ProjectorService } from '../../service/projector.service';
 })
 export class StatusComponent {
   api = inject(ApiService);
-  projectorService = inject(ProjectorService);
 
   result: string | undefined;
 
@@ -92,9 +90,5 @@ export class StatusComponent {
             break;
         }
       });
-  }
-
-  showAnswers() {
-    this.projectorService.postMessage('showAnswers');
   }
 }

--- a/src/app/control/status/status.component.ts
+++ b/src/app/control/status/status.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { ApiService, isApiError } from '../../service/api.service';
 import { FormsModule } from '@angular/forms';
 import { Status } from '../../service/api.interface';
@@ -19,6 +19,16 @@ export class StatusComponent {
   questionId: string | undefined;
 
   nowStatus = signal<Status | undefined>(undefined);
+  nowQuestionId = computed(() => {
+    const s = this.nowStatus();
+    if (s === undefined) {
+      return undefined;
+    } else if (s.status === 'open' || s.status === 'close') {
+      return s.questionId;
+    } else {
+      return undefined;
+    }
+  });
 
   sendStatus(status: string, questionId?: string) {
     switch (status) {


### PR DESCRIPTION
## 変更点
- 管理画面でフォームの値が変更されると「現在のステータス」の question_id が更新されてしまっていたため修正
- 回答表示ボタンと関連する処理を削除
- ステータスを「ゲーム開始前」に設定したとき、「現在のステータス」に「ゲーム開始前」と表示されるようにした

## 動作確認
- [x] adminでログインする
- [x] question_idを入力して問題を出題する
- [x] フォームの値を書き換える。「現在のステータス」の question_id が更新されない
- [x] 回答表示ボタンが表示されていない
- [x] ステータスをゲーム開始前に設定する。
- [x] 「現在のステータス」の部分に「ゲーム開始前」と表示される