### PR TITLE
🚑 正解を表示する前にiキーを押すと、sキーを押した時に画像が表示されてしまっていたため修正

### DIFF
--- a/src/app/projector/screen-question/screen-question.component.ts
+++ b/src/app/projector/screen-question/screen-question.component.ts
@@ -131,7 +131,8 @@ export class ScreenQuestionComponent implements OnDestroy {
   }
 
   showImage() {
-    if (this.nowStatus().status !== 'close') return;
+    // 正解の選択肢を表示していないときは画像を表示しない
+    if (this.nowStatus().status !== 'close' || !this.isShowAnswer()) return;
     this.isShowImage.set(true);
   }
 }


### PR DESCRIPTION
## 変更点
- 正解を表示する前にiキーを押してしまうと、sキーを押した時に即画像が表示されてしまっていたため修正

順番は sキーで正解表示、i キーで元画像の表示、の流れに固定したかったため修正しました

## 動作確認
- [x] 事前に元画像をpublicフォルダに入れておく
- [x] adminでログインし、プロジェクター画面を別ウインドウで開いておく
- [x] 問題を出題、回答を締め切る
- [x] プロジェクター画面で i キーを押す。画像が表示されない
- [x] s キーを押す。画像が表示されず、正解の選択肢だけが強調表示される
- [x] i キーを押す。元画像が表示される